### PR TITLE
Model sizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Useful training parameters:
 |--latent-size | size of the latent layer (compressed representation) in neurons, defaults to 4                   |
  |--fc-size | size of the fully connected layers immediately before and after the latent layer, defaults to 16 |
 | --batch-size | size of each training batch, defaults to 10                                                      |
-| --learning-rate | the optimisers learning rate, defaults to 0.001                                                  |                                                                             
+| --learning-rate | the optimisers learning rate, defaults to 0.001                                                  |
+| --stride | stride to use in convolutional layers", defaults to 2                                            |
+| --kernel-size | kernel size to use in convolutional layers, defaults to 3                                        |
+| --input-layer-count | number of input convolutional layers, defaults to auto (reduce image size to approximately 3x3)  |
+| --output-layer-count | number of output convolutional layers, defaults to auto (reduce image size to approximately 3x3)  |
 
 To apply:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@ A convolutional auto-encoder library for modelling image-to-image transformation
 
 ## Dependencies
 
-`train_cae` and `apply_cae` requires: pytorch, xarray, netcdf4
+`train_cae` and `apply_cae` requires: pytorch, xarray, netcdf4, dask
 
 `evaluate_cae` requires htmlfive (https://github.com/niallmcc/html-five), xarray, netcdf4, pillow, seaborn, matplotlib
+
+A suitable conda environment can be obtained using:
+
+```
+conda create -n pyt python=3.8 pytorch xarray dask netcdf4 pillow seaborn matplotlib scipy
+conda activate pyt
+git clone https://github.com/niallmcc/html-five.git
+cd html-five
+pip install -e .
+```
 
 ## Installation
 

--- a/src/cae_tools/cli/train_cae.py
+++ b/src/cae_tools/cli/train_cae.py
@@ -24,6 +24,11 @@ def main():
     parser.add_argument("--learning-rate", type=float, help="controls the rate at which model weights are updated", default=0.001)
     parser.add_argument("--method", choices=["conv", "var", "linear"], default="var", help="model training method: 'conv' for ConvAEModel or 'var' for VarAEModel or 'linear' for LinearModel")
     parser.add_argument("--layer-definitions-path", help="specify path of a JSON file with layer definitions", default=None)
+    parser.add_argument("--stride", type=int, help="stride to use in convolutional layers", default=2)
+    parser.add_argument("--kernel-size", type=int, help="kernel size to use in convolutional layers", default=3)
+    parser.add_argument("--input-layer-count", type=int, help="number of input convolutional layers", default=None)
+    parser.add_argument("--output-layer-count", type=int, help="number of output convolutional layers", default=None)
+    parser.add_argument("--latent-size", type=int, help="size of the latent space", default=4)
 
     args = parser.parse_args()
 

--- a/src/cae_tools/cli/train_cae.py
+++ b/src/cae_tools/cli/train_cae.py
@@ -28,7 +28,6 @@ def main():
     parser.add_argument("--kernel-size", type=int, help="kernel size to use in convolutional layers", default=3)
     parser.add_argument("--input-layer-count", type=int, help="number of input convolutional layers", default=None)
     parser.add_argument("--output-layer-count", type=int, help="number of output convolutional layers", default=None)
-    parser.add_argument("--latent-size", type=int, help="size of the latent space", default=4)
 
     args = parser.parse_args()
 

--- a/src/cae_tools/models/conv_ae_model.py
+++ b/src/cae_tools/models/conv_ae_model.py
@@ -31,7 +31,8 @@ class ConvAEModel:
 
     def __init__(self, normalise_input=True, normalise_output=True, batch_size=10,
                  nr_epochs=500, test_interval=10, encoded_dim_size=32, fc_size=128,
-                 lr=0.001, weight_decay=1e-5, use_gpu=True):
+                 lr=0.001, weight_decay=1e-5, use_gpu=True, conv_kernel_size=3, conv_stride=2,
+                 conv_input_layer_count=None, conv_output_layer_count=None):
         """
         Create a convolutional autoencoder general model
 
@@ -45,6 +46,10 @@ class ConvAEModel:
         :param lr: learning rate
         :param weight_decay: weight decay?
         :param use_gpu: use GPU if present
+        :param conv_kernel_size: size of the convolutional kernel to use
+        :param conv_stride: stride to use in convolutional layers
+        :param conv_input_layer_count: number of input convolutional layers to use
+        :param conv_output_layer_count: number of output convolutional layers to use
         """
 
         self.normalise_input = normalise_input
@@ -60,6 +65,10 @@ class ConvAEModel:
         self.lr = lr
         self.weight_decay = weight_decay
         self.use_gpu = use_gpu
+        self.conv_kernel_size = conv_kernel_size
+        self.conv_stride = conv_stride
+        self.conv_input_layer_count = conv_input_layer_count
+        self.conv_output_layer_count = conv_output_layer_count
         self.spec = None
         self.history = {'train_loss': [], 'test_loss': [], 'nr_epochs':0 }
         self.optim = None
@@ -90,7 +99,11 @@ class ConvAEModel:
             "lr": self.lr,
             "weight_decay": self.weight_decay,
             "normalise_input": self.normalise_input,
-            "normalise_output": self.normalise_output
+            "normalise_output": self.normalise_output,
+            "conv_kernel_size": self.conv_kernel_size,
+            "conv_stride": self.conv_stride,
+            "conv_input_layer_count": self.conv_input_layer_count,
+            "conv_output_layer_count": self.conv_output_layer_count
         }
 
         parameters_path = os.path.join(to_folder, "parameters.json")
@@ -131,6 +144,11 @@ class ConvAEModel:
             self.weight_decay = parameters["weight_decay"]
             self.normalise_input = parameters["normalise_input"]
             self.normalise_output = parameters["normalise_output"]
+
+            self.conv_kernel_size = parameters.get("conv_kernel_size",None)
+            self.conv_stride = parameters.get("conv_stride",None)
+            self.conv_input_layer_count = parameters.get("conv_input_layer_count",None)
+            self.conv_output_layer_count = parameters.get("conv_output_layer_count",None)
 
         history_path = os.path.join(from_folder, "history.json")
         with open(history_path) as f:
@@ -230,7 +248,10 @@ class ConvAEModel:
 
         if not self.spec:
             self.spec = create_model_spec(input_size=(input_y, input_x), input_channels=input_chan,
-                                 output_size=(output_y, output_x), output_channels=output_chan)
+                                 output_size=(output_y, output_x), output_channels=output_chan,
+                                 kernel_size=self.conv_kernel_size, stride=self.conv_stride,
+                                 input_layer_count=self.conv_input_layer_count, output_layer_count=self.conv_output_layer_count)
+            print(self.spec)
 
         if not self.encoder:
             self.encoder = Encoder(self.spec.get_input_layers(), encoded_space_dim=self.encoded_dim_size, fc_size=self.fc_size)

--- a/src/cae_tools/models/model_sizer.py
+++ b/src/cae_tools/models/model_sizer.py
@@ -18,7 +18,7 @@ class LayerSpec:
     def __init__(self, is_input=True, kernel_size=3, stride=2, input_dimensions=None, output_dimensions=None, output_padding_y=0,
                  output_padding_x=0):
         self.is_input = is_input
-        self.kernel_size = kernel_size
+        self.kernel_size = kernel_size # note this may be a integer or a (h,w) tuple
         self.stride = stride
         self.input_dimensions = input_dimensions
         self.output_dimensions = output_dimensions
@@ -51,7 +51,7 @@ class LayerSpec:
     def save(self):
         return {
             "is_input": self.is_input,
-            "kernel_size": self.kernel_size,
+            "kernel_size": list(self.kernel_size) if isinstance(self.kernel_size,tuple) else self.kernel_size,
             "stride": self.stride,
             "output_padding_x": self.output_padding_x,
             "output_padding_y": self.output_padding_y,
@@ -62,6 +62,8 @@ class LayerSpec:
     def load(self, from_obj):
         self.is_input = from_obj["is_input"]
         self.kernel_size = from_obj["kernel_size"]
+        if isinstance(self.kernel_size,list):
+            self.kernel_size = tuple(self.kernel_size)
         self.stride = from_obj["stride"]
         self.output_padding_x = from_obj["output_padding_x"]
         self.output_padding_y = from_obj["output_padding_y"]
@@ -122,8 +124,9 @@ def create_model_spec(input_size=(7, 7), input_channels=1, output_size=(28, 28),
         input_dims = (int(channels), int(size_y), int(size_x))
         size_x = ((size_x - (kernel_size - 1) - 1) // stride) + 1
         size_y = ((size_y - (kernel_size - 1) - 1) // stride) + 1
-        if (input_layer_count is not None and len(input_layers) >= input_layer_count) or min(size_x,size_y) < limit:
-            break
+        if len(input_layers): # ensure we have at least one layer
+            if (input_layer_count is not None and len(input_layers) >= input_layer_count) or min(size_x,size_y) < limit:
+                break
         channels *= 2
         output_dims = (int(channels), int(size_y), int(size_x))
         input_layers.append(LayerSpec(True, kernel_size, stride, input_dims, output_dims))
@@ -135,26 +138,30 @@ def create_model_spec(input_size=(7, 7), input_channels=1, output_size=(28, 28),
     channels = output_channels
     while True:
         (size_y, size_x) = size
-        if (output_layer_count is not None and len(output_layers) >= output_layer_count) \
-                or size_x <= reduced_size_x or size_y <= reduced_size_y:
-            break
+        if len(output_layers): # ensure we have at least one layer
+            if (output_layer_count is not None and len(output_layers) >= output_layer_count) \
+                    or size_x <= reduced_size_x or size_y <= reduced_size_y:
+                break
 
         output_dims = (int(channels), int(size_y), int(size_x))
-        effective_kernel_size = kernel_size
-        while  (size_x - (effective_kernel_size - 1) - 1) % stride != 0:
-            effective_kernel_size += 1
-            print(effective_kernel_size)
-        input_size_x = ((size_x - (effective_kernel_size - 1) - 1) // stride) + 1
-        input_size_y = ((size_y - (effective_kernel_size - 1) - 1) // stride) + 1
+        effective_kernel_size_x = effective_kernel_size_y = kernel_size
+        while  (size_x - (effective_kernel_size_x - 1) - 1) % stride != 0:
+            effective_kernel_size_x += 1
+        while  (size_y - (effective_kernel_size_y - 1) - 1) % stride != 0:
+            effective_kernel_size_y += 1
+
+        effective_kernel_size = (effective_kernel_size_y, effective_kernel_size_x) \
+            if effective_kernel_size_x != effective_kernel_size_y \
+            else effective_kernel_size_x
+
+        input_size_x = ((size_x - (effective_kernel_size_x - 1) - 1) // stride) + 1
+        input_size_y = ((size_y - (effective_kernel_size_y - 1) - 1) // stride) + 1
 
         channels *= 2
         input_dims = (int(channels), int(input_size_y), int(input_size_x))
-        output_layers.insert(0, LayerSpec(False, effective_kernel_size, stride, input_dims, output_dims))
+        output_layers.insert(0, LayerSpec(False, effective_kernel_size,  stride, input_dims, output_dims))
         size = (input_size_y, input_size_x)
 
     spec = ModelSpec(input_layers, output_layers)
     return spec
 
-# spec = create_model_spec(input_size=(100, 100), input_channels=1, output_size=(100, 100), output_channels=1, stride=2,
-#                      kernel_size=3, limit=3, input_layer_count=1, output_layer_count=5)
-# print(spec)

--- a/test/cli/test_cli.sh
+++ b/test/cli/test_cli.sh
@@ -5,7 +5,7 @@
 
 here=`dirname $0`
 
-NR_EPOCHS=500
+NR_EPOCHS=50
 
 # for each supported method, go through the train, apply, evaluate, retrain, apply, evaluate cycle
 
@@ -13,7 +13,7 @@ for method in linear conv var
 do
   echo tests for $method
   echo training model
-  train_cae $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
+  train_cae $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
 
   echo applying trained model to training and test datasets
   apply_cae $here/../data/circle/16x16_256x256/train.nc $here/results/$method/train_scores.nc --model-folder=$here/results/$method/mymodel --input-variables lowres --prediction-variable hires_estimate


### PR DESCRIPTION
add training parameters to explicitly control 

| Name | Description                                                                                      |
|------|--------------------------------------------------------------------------------------------------|
| --stride | stride to use in convolutional layers, defaults to 2                                            |
| --kernel-size | kernel size to use in convolutional layers, defaults to 3                                        |
| --input-layer-count | number of input convolutional layers, defaults to auto (reduce image size to approximately 3x3)  |
| --output-layer-count | number of output convolutional layers, defaults to auto (reduce image size to approximately 3x3)  |

avoid using padding when setting up convolutional layers automatically in the model_sizer
* instead, increase the kernel size when necessary in the decoder layers
* kernel size may be increased by as much as stride-1 units
