### PR TITLE
model database for tracking #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ A convolutional auto-encoder library for modelling image-to-image transformation
 
 `train_cae` and `apply_cae` requires: pytorch, xarray, netcdf4, dask
 
-`evaluate_cae` requires htmlfive (https://github.com/niallmcc/html-five), xarray, netcdf4, pillow, seaborn, matplotlib
+`evaluate_cae` requires xarray, netcdf4, pillow, seaborn, matplotlib
 
 A suitable conda environment can be obtained using:
 
 ```
 conda create -n pyt python=3.8 pytorch xarray dask netcdf4 pillow seaborn matplotlib scipy
 conda activate pyt
-git clone https://github.com/niallmcc/html-five.git
-cd html-five
-pip install -e .
 ```
 
 ## Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ console_scripts =
     train_cae = cae_tools.cli.train_cae:main
     apply_cae = cae_tools.cli.apply_cae:main
     evaluate_cae = cae_tools.cli.evaluate_cae:main
+    query_database = cae_tools.cli.query_database
 
 [options.packages.find]
 where = src

--- a/src/cae_tools/cli/evaluate_cae.py
+++ b/src/cae_tools/cli/evaluate_cae.py
@@ -15,7 +15,7 @@
 
 import argparse
 
-from cae_tools.utils.evaluate import ModelEvaluator
+from cae_tools.models.model_evaluator import ModelEvaluator
 
 
 def main():
@@ -33,6 +33,8 @@ def main():
     parser.add_argument("--prediction-variable", help="name of the prediction variable to create in output data",
                        default="")
 
+    parser.add_argument("--database-path", type=str, help="path to a database to store evaluation results", default=None)
+
     args = parser.parse_args()
 
     mt = ModelEvaluator(train_path=args.training_path,
@@ -41,5 +43,6 @@ def main():
                         output_variable=args.output_variable,
                         output_html_path=args.output_html_path,
                         model_path=args.model_folder,
-                        model_output_variable=args.prediction_variable)
+                        model_output_variable=args.prediction_variable,
+                        database_path=args.database_path)
     mt.run()

--- a/src/cae_tools/cli/plot_data.py
+++ b/src/cae_tools/cli/plot_data.py
@@ -28,14 +28,12 @@ def main():
     parser.add_argument("--input-variables", nargs="+", help="name of the input variable(s) in training/test data", required=True)
     parser.add_argument("--output-variable", help="name of the output variable in training/test data", required=True)
 
-    parser.add_argument("--vmin", type=float, help="minimum value for scale", default=265)
-    parser.add_argument("--vmax", type=float, help="minimum value for scale", default=315)
-
 
     args = parser.parse_args()
 
-    p = DataPlotter(data_path=args.data_path, input_variables=args.input_variables, output_variable=args.output_variable, output_html_path=args.output_html_path,
-                    vmin=args.vmin, vmax=args.vmax)
+    p = DataPlotter(data_path=args.data_path,
+                    input_variables=args.input_variables, output_variable=args.output_variable,
+                    output_html_path=args.output_html_path)
     p.run()
 
 if __name__ == '__main__':

--- a/src/cae_tools/cli/query_database.py
+++ b/src/cae_tools/cli/query_database.py
@@ -1,0 +1,12 @@
+from cae_tools.utils.model_database import ModelDatabase
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("database_path")
+    args = parser.parse_args()
+    md = ModelDatabase(args.database_path)
+    md.dump()
+
+if __name__ == '__main__':
+    main()

--- a/src/cae_tools/cli/train_cae.py
+++ b/src/cae_tools/cli/train_cae.py
@@ -28,6 +28,9 @@ def main():
     parser.add_argument("--kernel-size", type=int, help="kernel size to use in convolutional layers", default=3)
     parser.add_argument("--input-layer-count", type=int, help="number of input convolutional layers", default=None)
     parser.add_argument("--output-layer-count", type=int, help="number of output convolutional layers", default=None)
+    parser.add_argument("--model-id", type=str, help="specify the model id when creating a model", default=None)
+    parser.add_argument("--database-path", type=str, help="path to a database to store evaluation results",
+                        default=None)
 
     args = parser.parse_args()
 
@@ -50,12 +53,15 @@ def main():
     else:
         if args.method == "conv":
             mt = ConvAEModel(fc_size=args.fc_size, encoded_dim_size=args.latent_size, nr_epochs=args.nr_epochs,
-                             batch_size=args.batch_size, lr=args.learning_rate)
+                             batch_size=args.batch_size, lr=args.learning_rate, database_path=args.database_path)
         elif args.method == "var":
             mt = VarAEModel(fc_size=args.fc_size, encoded_dim_size=args.latent_size, nr_epochs=args.nr_epochs,
                         batch_size=args.batch_size, lr=args.learning_rate)
         elif args.method == "linear":
             mt = LinearModel(batch_size=args.batch_size, nr_epochs=args.nr_epochs, lr=args.learning_rate)
+
+        if args.model_id:
+            mt.set_model_id(args.model_id)
 
         # if specified, use the encoder/decoder layer specifications
         if args.layer_definitions_path:
@@ -64,5 +70,5 @@ def main():
                 spec.load(json.loads(f.read()))
                 mt.spec = spec
 
-    mt.train(args.input_variables, args.output_variable, args.training_path, args.test_path)
-    mt.save(args.model_folder)
+    mt.train(args.input_variables, args.output_variable, args.training_path, args.test_path, args.model_folder)
+

--- a/src/cae_tools/models/base_model.py
+++ b/src/cae_tools/models/base_model.py
@@ -13,20 +13,15 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .html5.html5_builder import ElementFragment
+import uuid
 
+class BaseModel:
 
-class TableFragment(ElementFragment):
+    def __init__(self):
+        self.model_id = str(uuid.uuid4())
 
-    def __init__(self, attrs={},style={}):
-        super().__init__("table",attrs,style)
+    def set_model_id(self, model_id):
+        self.model_id = model_id
 
-    def add_row(self, cells):
-        tr = self.add_element("tr")
-        for cell in cells:
-            td = tr.add_element("td")
-            if isinstance(cell,str):
-                td.add_text(cell)
-            else:
-                td.add_fragment(cell)
-
+    def get_model_id(self):
+        return self.model_id

--- a/src/cae_tools/models/model_evaluator.py
+++ b/src/cae_tools/models/model_evaluator.py
@@ -19,19 +19,19 @@ from PIL import Image
 from matplotlib import cm
 import numpy as np
 import seaborn as sns
-
+import datetime
 import pandas as pd
 import math
 import json
-
-from htmlfive.html5_builder import Html5Builder
-from .table_fragment import TableFragment
-from .image_fragment import InlineImageFragment
-from .utils import add_exo_dependencies
-from .tab_fragment import TabbedFragment
 import tempfile
 
-from .utils import anti_aliasing_style
+from ..utils.html5.html5_builder import Html5Builder
+from ..utils.table_fragment import TableFragment
+from ..utils.image_fragment import InlineImageFragment
+from ..utils.utils import add_exo_dependencies
+from ..utils.tab_fragment import TabbedFragment
+from ..utils.model_database import ModelDatabase
+from ..utils.utils import anti_aliasing_style
 
 def save_image(arr,vmin,vmax,path,cmap_name):
     if cmap_name == "viridis":
@@ -44,10 +44,10 @@ def save_image(arr,vmin,vmax,path,cmap_name):
     im.save(path)
 
 
-
 class ModelEvaluator:
 
-    def __init__(self, train_path, test_path, input_variables, output_variable, output_html_path, model_output_variable="", model_path=""):
+    def __init__(self, train_path, test_path, input_variables, output_variable, output_html_path, model_output_variable="", model_path="",
+                 database_path=""):
         self.train_path = train_path
         self.test_path = test_path
         self.input_variables = input_variables
@@ -55,6 +55,8 @@ class ModelEvaluator:
         self.output_html_path = output_html_path
         self.model_path = model_path
         self.model_output_variable = model_output_variable
+        self.database_path = database_path
+        self.db = ModelDatabase(database_path) if database_path else None
 
     def compute_measure(self, dataset, idx, measure):
         predicted = dataset[self.model_output_variable][idx, 0, :, :].values
@@ -81,7 +83,6 @@ class ModelEvaluator:
                 training_losses = json.loads(f.read())
             with open(os.path.join(self.model_path,"parameters.json")) as f:
                 training_parameters = json.loads(f.read())
-
 
         plot_variables = self.input_variables+[self.output_variable]
         if self.model_output_variable:
@@ -213,4 +214,9 @@ class ModelEvaluator:
 
         with open(self.output_html_path,"w") as f:
             f.write(builder.get_html())
+
+        # TODO write results into the model database.  Also make the html generation more optional
+
+
+
 

--- a/src/cae_tools/utils/html5/html5_builder.py
+++ b/src/cae_tools/utils/html5/html5_builder.py
@@ -1,0 +1,213 @@
+# MIT License
+#
+# Copyright (c) 2023 Niall McCarroll
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import xml.dom.minidom
+from xml.dom.minidom import getDOMImplementation
+import typing
+from .html5_exporter import Html5Exporter
+
+
+class Fragment:
+
+    def get_node(self, builder:"Html5Builder"):
+        pass
+
+
+class TextFragment(Fragment):
+    """
+    Represent an HTML5 text node.
+    """
+
+    def __init__(self, text):
+        self.text = text
+
+    def get_node(self, builder):
+        return builder.doc.createTextNode(self.text)
+
+
+class ElementFragment(Fragment):
+    """
+    Represent a generic HTML5 element node.
+    """
+
+    def __init__(self, tag: str, attrs: typing.Dict[str, str] = {},
+                 style: typing.Dict[str, str] = {}):
+        self.tag = tag
+        self.attrs = attrs
+        self.style = style
+        self.child_fragments = []
+
+
+    def add_element(self, tag: str, attrs: typing.Dict[str, str] = {},
+                    style: typing.Dict[str, str] = {}) -> "ElementFragment":
+        """
+        Add a child element fragment to this fragment
+
+        Arguments:
+            tag: the tag name to add
+            attrs: dictionary containing the names and values of attributes.
+            style: dictionary contiaining the names and values of CSS styles to apply.
+
+        Returns:
+             The child fragment that was added
+        """
+        fragment = ElementFragment(tag, attrs, style)
+        self.add_fragment(fragment)
+        return fragment
+
+    def add_text(self, text: str) -> "ElementFragment":
+        """
+        Add a child text fragment to this fragment
+
+        Arguments:
+            text: the text to include
+        """
+        fragment = TextFragment(text)
+        self.add_fragment(fragment)
+        return self
+
+    def set_attribute(self,name,value) -> "ElementFragment":
+        self.attrs[name] = value
+        return self
+
+    def set_style(self, name, value) -> "ElementFragment":
+        self.style[name] = value
+        return self
+
+    def add_fragment(self, fragment: Fragment) -> "Html5Builder":
+        self.child_fragments.append(fragment)
+        return self
+
+    def get_node(self, builder: "Html5Builder") -> xml.dom.minidom.Node:
+        node = builder.doc.createElement(self.tag)
+        for (name, value) in self.attrs.items():
+            node.setAttribute(name, value)
+        if self.style:
+            style_value = ""
+            for (name, value) in self.style.items():
+                style_value += name + ":" + str(value) + ";"
+            node.setAttribute("style", style_value)
+        for fragment in self.child_fragments:
+            node.appendChild(fragment.get_node(builder))
+        return node
+
+
+class RawFragment:
+
+    def __init__(self, node):
+        self.node = node
+
+    def get_node(self, builder):
+        return self.node
+
+class Html5Builder:
+    """
+    Create and populate an html5 document
+
+    A way you might use me is:
+
+    >>> builder = Html5Builder(language="en")
+    >>> builder.head().add_element("title").add_text("Title!")
+    >>> builder.body().add_element("h1",{"id":"heading"}).add_text("Heading")
+    >>> builder.body().add_element("div").add_text("Lorem Ipsum")
+    >>> print(builder.get_html())
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>
+                Title!
+            </title>
+        </head>
+        <body>
+            <h1 id="heading">
+                Heading
+            </h1>
+            <div>
+                Lorem Ipsum
+            </div>
+        </body>
+    </html>
+    """
+
+    def __init__(self, language: str = "", id_suffix="_bld", width=None):
+        self.doc = getDOMImplementation().createDocument(None, "html", None)
+        self.root = self.doc.documentElement
+        if language:
+            self.root.setAttribute("lang", language)
+        self.__head = ElementFragment("head")
+        self.__body = ElementFragment("body")
+        self.css = ""
+        if width:
+            self.css = "body { margin-left:auto; margin-right:auto; position:relative; width:%dpx; }"%(width)
+        self.post_build_fns = []
+        self.id_counters = {}
+        self.id_suffix = id_suffix
+
+    def head(self) -> ElementFragment:
+        """
+        Get the head fragment of the document being built
+
+        Returns:
+             Html <head> fragment
+        """
+        return self.__head
+
+    def body(self) -> ElementFragment:
+        """
+        Get the body fragment of the document being built
+
+        Returns:
+             Html <body> fragment
+        """
+        return self.__body
+
+    def get_html(self) -> str:
+        """
+        Get an HTML5 string representation of the document being built
+
+        Returns:
+             Html formatted string
+        """
+        exporter = Html5Exporter()
+        if self.css:
+            self.__head.add_element("style").add_text(self.css)
+        head_node = self.__head.get_node(self)
+        body_node = self.__body.get_node(self)
+
+        for fn in self.post_build_fns:
+            fn(head_node,body_node)
+
+        self.root.appendChild(head_node)
+        self.root.appendChild(body_node)
+        return exporter.export(self.doc).strip()
+
+    def register_post_build(self,fn):
+        self.post_build_fns.append(fn)
+
+    def get_next_id(self,prefix):
+        if prefix not in self.id_counters:
+            self.id_counters[prefix] = 0
+        id = prefix+str(self.id_counters[prefix])+self.id_suffix
+        self.id_counters[prefix] =  1 + self.id_counters[prefix]
+        return id
+
+
+

--- a/src/cae_tools/utils/html5/html5_common.py
+++ b/src/cae_tools/utils/html5/html5_common.py
@@ -1,0 +1,26 @@
+# MIT License
+#
+# Copyright (c) 2023 Niall McCarroll
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+void_elements = "area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr".split(",")
+require_end_tags = "script,style,form,ins,del,rt,pre,meter,textarea".split(",")
+
+HTML5_DOCTYPE = "<!DOCTYPE html>"

--- a/src/cae_tools/utils/html5/html5_exporter.py
+++ b/src/cae_tools/utils/html5/html5_exporter.py
@@ -1,0 +1,136 @@
+# MIT License
+#
+# Copyright (c) 2023 Niall McCarroll
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import io
+import html as htmlutils
+import xml.dom.minidom
+from .html5_common import HTML5_DOCTYPE, require_end_tags, void_elements
+
+
+class Html5Exporter:
+    """
+    Export an XML dom as html5
+
+    Args
+        indent_spaces: number of spaces to make up each indent
+
+    A way you might use me is:
+
+    >>> from htmlfive import Html5Exporter
+    >>> from xml.dom.minidom import getDOMImplementation
+    >>> doc = getDomImplementation().createDocument(None, "html", None)
+    >>> body = doc.createElement("body")
+    >>> doc.documentElement.appendChild(body)
+    >>> txt = doc.createTextNode("Hello")
+    >>> body.appendChild(txt)
+    >>> exporter = Html5Exporter()
+    >>> html = exporter.export(doc)
+    >>> print(html)
+    <!DOCTYPE html>
+    <html>
+        <body>
+            Hello
+        </body>
+    </html>
+    """
+
+    def __init__(self, indent_spaces: int = 4):
+        self.indent_spaces = indent_spaces
+
+    def __is_ws(self, txt):
+        txt = txt.replace(" ", "").replace("\t", "").replace("\n", "")
+        return txt == ""
+
+    def __exportElement(self, ele, indent):
+        self.of.write(indent * " " * self.indent_spaces)
+        self.of.write("<" + ele.tagName)
+        attr_count = 0
+        for (k, v) in ele.attributes.items():
+
+            if v is None:
+                self.of.write(" %s" % k)
+            else:
+                if not isinstance(v, str):
+                    v = str(v)
+                if '"' in v:
+                    if "'" in v:
+                        self.of.write(' %s="%s"' % (k, htmlutils.escape(v)))
+                    else:
+                        self.of.write(" %s='%s'" % (
+                            k, htmlutils.escape(v, quote=False)))  # single quote values containing double quote
+                else:
+                    self.of.write(' %s="%s"' % (k, htmlutils.escape(v, quote=False)))
+            attr_count += 1
+        child_count = len(ele.childNodes)
+
+        if ele.tagName in require_end_tags or child_count > 0:
+            self.of.write(">")
+            if child_count:
+                self.of.write("\n")
+                for childNode in ele.childNodes:
+                    if childNode.nodeType == childNode.ELEMENT_NODE:
+                        self.__exportElement(childNode, indent + 1)
+                    elif childNode.nodeType == childNode.TEXT_NODE:
+                        self.__exportText(childNode, indent + 1)
+                    elif childNode.nodeType == childNode.COMMENT_NODE:
+                        self.__exportComment(childNode, indent + 1)
+                self.of.write(" " * indent * self.indent_spaces + "</%s>" % ele.tagName)
+            else:
+                self.of.write("</%s>" % ele.tagName)
+        else:
+            if ele.tagName not in void_elements:
+                self.of.write("/>")
+            else:
+                self.of.write(">")
+        self.of.write("\n")
+
+    def __exportText(self, tn, indent):
+        txt = tn.data.rstrip(" \n").lstrip(" \n")
+        if not self.__is_ws(txt):
+            self.of.write(" " * indent * self.indent_spaces)
+            # self.of.write(htmlutils.escape(txt))
+            self.of.write(txt)
+            self.of.write("\n")
+
+    def __exportComment(self, cn, indent):
+        txt = cn.data.rstrip(" \n").lstrip(" \n")
+        self.of.write(" " * indent * self.indent_spaces)
+        self.of.write("<!--")
+        self.of.write(txt)
+        self.of.write("-->")
+        self.of.write("\n")
+
+    def export(self, doc: xml.dom.minidom.Document) -> str:
+        """
+        Export a DOM to an HTML string.
+
+        Args:
+            doc: the DOM document to export
+
+        Returns:
+            A string containing the HTML
+        """
+        with io.StringIO() as self.of:
+            self.of.write(HTML5_DOCTYPE + "\n")
+            ele = doc.documentElement
+            self.__exportElement(ele, 0)
+            return self.of.getvalue()

--- a/src/cae_tools/utils/image_fragment.py
+++ b/src/cae_tools/utils/image_fragment.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from htmlfive.html5_builder import Html5Builder, Fragment, ElementFragment
+from .html5.html5_builder import Html5Builder, Fragment, ElementFragment
 import base64
 
 from .utils import add_exo_dependencies, prepare_attrs

--- a/src/cae_tools/utils/model_database.py
+++ b/src/cae_tools/utils/model_database.py
@@ -1,0 +1,56 @@
+
+import sqlite3
+import os
+import datetime
+import json
+
+SCHEMA_VERSION = "0.1"
+
+class ModelDatabase:
+
+    def __init__(self,database_path):
+        if not os.path.exists(database_path):
+            self.conn = sqlite3.connect(database_path)
+            curs = self.conn.cursor()
+            curs.execute(
+                "CREATE TABLE MODEL_SCHEMA(version STRING)")
+            curs.execute("INSERT INTO MODEL_SCHEMA VALUES (?)",(SCHEMA_VERSION,))
+            curs.execute(
+                "CREATE TABLE MODEL_TRAINING(timestamp DATE, model_id STRING, model_type STRING, target_variable STRING, input_variables STRING, model_description STRING, model_path STRING, train_path STRING, train_loss FLOAT, test_path STRING, test_loss FLOAT, hyperparameters STRING, spec STRING)")
+            curs.execute(
+                "CREATE TABLE MODEL_EVALUATIONS(timestamp DATE, model_id STRING, train_path STRING, test_path STRING, metrics STRING)")
+            self.conn.commit()
+        else:
+            self.conn = sqlite3.connect(database_path)
+
+    def add_training_result(self, model_id, model_type, target_variable, input_variables, description, model_path, train_path, train_loss, test_path, test_loss, hyperparameters, spec):
+        curs = self.conn.cursor()
+        curs.execute("INSERT INTO MODEL_TRAINING VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)", (
+            datetime.datetime.now(), model_id, model_type, target_variable, json.dumps(input_variables), description, model_path, train_path, train_loss, test_path, test_loss, json.dumps(hyperparameters),
+            json.dumps(spec)))
+        self.conn.commit()
+
+    def add_evaluation_result(self, model_id, train_path, test_path, metrics):
+        curs = self.conn.cursor()
+        dt_now = datetime.datetime.now()
+        curs.execute("INSERT INTO MODEL_EVALUATIONS VALUES(?,?,?,?,?)", (
+            dt_now, model_id, train_path, test_path, json.dumps(metrics)))
+        self.conn.commit()
+
+    def dump(self):
+        curs = self.conn.cursor()
+        print("MODEL_SCHEMA")
+        rs = curs.execute("SELECT * FROM MODEL_SCHEMA").fetchall()
+        for row in rs:
+            print(json.dumps(row))
+        print("\nMODEL_TRAINING")
+        rs = curs.execute("SELECT * FROM MODEL_TRAINING").fetchall()
+        for row in rs:
+            print(json.dumps(row))
+        print("\nMODEL_EVALUTATIONS")
+        rs = curs.execute("SELECT * FROM MODEL_EVALUATIONS").fetchall()
+        for row in rs:
+            print(json.dumps(row))
+
+
+

--- a/src/cae_tools/utils/tab_fragment.py
+++ b/src/cae_tools/utils/tab_fragment.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from htmlfive.html5_builder import ElementFragment
+from .html5.html5_builder import ElementFragment
 
 class TabbedFragment(ElementFragment):
 

--- a/test/cli/test_cli.sh
+++ b/test/cli/test_cli.sh
@@ -13,7 +13,7 @@ for method in linear conv var
 do
   echo tests for $method
   echo training model
-  train_cae $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
+  train_cae --database-path $here/results.db $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
 
   echo applying trained model to training and test datasets
   apply_cae $here/../data/circle/16x16_256x256/train.nc $here/results/$method/train_scores.nc --model-folder=$here/results/$method/mymodel --input-variables lowres --prediction-variable hires_estimate
@@ -23,7 +23,7 @@ do
   evaluate_cae $here/results/$method/train_scores.nc $here/results/$method/test_scores.nc $here/results/$method/model_evaluation.html --input-variables lowres --output-variable hires --model-folder=$here/results/$method/mymodel --prediction-variable hires_estimate
 
   echo retrain model
-  train_cae $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --continue-training --input-variables lowres --output-variable=hires --model-folder=$here/results/$method/mymodel --nr-epochs=$NR_EPOCHS
+  train_cae --database-path $here/results.db $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --continue-training --input-variables lowres --output-variable=hires --model-folder=$here/results/$method/mymodel --nr-epochs=$NR_EPOCHS
 
   echo applying retrained model to training and test datasets
   apply_cae $here/../data/circle/16x16_256x256/train.nc $here/results/$method/retrain_scores.nc --model-folder=$here/results/$method/mymodel --input-variables lowres --prediction-variable hires_estimate

--- a/test/unittests/quick_cae.py
+++ b/test/unittests/quick_cae.py
@@ -17,7 +17,7 @@ import unittest
 import os.path
 
 from cae_tools.models.conv_ae_model import ConvAEModel
-from cae_tools.utils.evaluate import ModelEvaluator
+from cae_tools.models.model_evaluator import ModelEvaluator
 
 import test_specs
 

--- a/test/unittests/quick_linear.py
+++ b/test/unittests/quick_linear.py
@@ -17,7 +17,7 @@ import unittest
 import os.path
 
 from cae_tools.models.linear_model import LinearModel
-from cae_tools.utils.evaluate import ModelEvaluator
+from cae_tools.models.model_evaluator import ModelEvaluator
 
 import test_specs
 


### PR DESCRIPTION
* Remove dependency on htmlfive repo by incorporating required code directly under `cae_tools.utils.html5`
* Add a model_id to each model instance for tracking
* Create entries in an optional database when a model is trained, retrained (pass --database-path <path> on the command line to use this feature).

database schema - model training tracking:

```
CREATE TABLE MODEL_TRAINING(
     timestamp DATE, 
     model_id STRING, 
     model_type STRING, 
     target_variable STRING, 
     input_variables STRING, 
     model_description STRING, 
     model_path STRING, 
     train_path STRING, 
     train_loss FLOAT, 
     test_path STRING, 
     test_loss FLOAT, 
     hyperparameters STRING, 
     spec STRING)
```

Note that `input_variables`, `hyperparameters` and `spec` are JSON-encoded strings

Future work:
A tool query_database will be developed to intertrrogate the database (see `cae_tools.utils.query_database.py`), initially this dumps the database contents.

Model evaluation runs will also be tracked in the database.