### PR TITLE
Multi file inputs for train and apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ pip install -e .
 To train:
 
 ```
-train_cae test/data/16x16_256x256/train.nc test/data/16x16_256x256/test.nc --model-folder=/tmp/mymodel --input-variables lowres --output-variable=hires --nr-epochs=500 --method conv       
+train_cae --train-inputs test/data/16x16_256x256/train.nc --test-inputs test/data/16x16_256x256/test.nc --model-folder=/tmp/mymodel --input-variables lowres --output-variable=hires --nr-epochs=500 --method conv       
 ```
-method options are "conv" or "var" for convolutional autoencder or variational autoencoder
+method options are "conv" or "var" for convolutional autoencder or variational autoencoder, "linear" for a simple linear model
 
 Useful training parameters:
 
@@ -73,16 +73,19 @@ For help, run `train_cae --help` or `apply_cae --help`
 See source code for ConvAEModel for documentation 
 
 ```python
-
+import xarray as xr
 from cae_tools.models.conv_ae_model import ConvAEModel
-from cae_tools.utils.evaluate import ModelEvaluator
+from cae_tools.models.model_evaluator import ModelEvaluator
 
 train_path = "train.nc"
 test_path = "test.nc"
 
 # train the model to reconstruct variable "hires" from variable "lowres"
 mt = ConvAEModel(fc_size=8, encoded_dim_size=4, nr_epochs=500)
-mt.train(["lowres"], "hires", train_path, test_path)
+
+train_ds = xr.open_dataset(train_path)
+test_ds = xr.open_dataset(test_path)
+mt.train(["lowres"], "hires", training_ds=train_ds, testing_ds=test_ds, training_paths=train_path, testing_paths=test_path)
 
 # print a summary of the layers
 print(mt.summary())

--- a/README.md
+++ b/README.md
@@ -96,8 +96,12 @@ mt.save("/tmp/mymodel")
 # now reload the trained model to create estimates of the "hires" variable from the train/test datasets
 mt2 = ConvAEModel()
 mt2.load("/tmp/mymodel")
-mt2.apply(train_path, ["lowres"], "train_scores.nc", "hires_estimate")
-mt2.apply(test_path, ["lowres"], "test_scores.nc", "hires_estimate")
+
+mt2.apply(train_ds, ["lowres"], "hires_estimate")
+train_ds.to_netcdf( "train_scores.nc")
+
+mt2.apply(test_ds, ["lowres"], "hires_estimate")
+test_ds.to_netcdf("test_scores.nc")
 
 # perform model evaluation, write results to evaluation_results.html
 me = ModelEvaluator("train_scores.nc","test_scores.nc",["lowres"],"hires","evaluation_results.html","hires_estimate","/tmp/mymodel")

--- a/src/cae_tools/cli/apply_cae.py
+++ b/src/cae_tools/cli/apply_cae.py
@@ -16,6 +16,7 @@
 import argparse
 import os
 import json
+import xarray as xr
 
 from cae_tools.models.conv_ae_model import ConvAEModel
 from cae_tools.models.var_ae_model import VarAEModel
@@ -25,7 +26,7 @@ from cae_tools.models.linear_model import LinearModel
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("data_path", help="path to netcdf4 file containing data to which model is applied")
+    parser.add_argument("data_paths", nargs="+", help="path to netcdf4 file(s) containing data to which model is applied")
     parser.add_argument("output_path", help="path to write the netcdf4 file containing input data plus model outputs")
 
     parser.add_argument("--model-folder", help="folder to save the trained model to", required=True)
@@ -33,8 +34,13 @@ def main():
     parser.add_argument("--prediction-variable", help="name of the prediction variable to create in output data",
                         default="model_output")
 
-
     args = parser.parse_args()
+
+    input_ds = [xr.open_dataset(data_path) for data_path in args.data_paths]
+    target_dimension = input_ds[0][args.input_variables[0]].dims[0]
+    score_ds = input_ds[0] if len(input_ds) == 1 else xr.concat(input_ds, dim=target_dimension)
+
+    print("Applying model for %d cases" % score_ds[target_dimension].shape[0])
 
     parameters_path = os.path.join(args.model_folder, "parameters.json")
     with open(parameters_path) as f:
@@ -48,4 +54,8 @@ def main():
         mt = LinearModel()
 
     mt.load(args.model_folder)
-    mt.apply(args.data_path, args.input_variables, args.output_path, args.prediction_variable)
+    mt.apply(score_ds, args.input_variables, args.prediction_variable)
+    score_ds.to_netcdf(args.output_path)
+
+if __name__ == '__main__':
+    main()

--- a/src/cae_tools/cli/train_cae.py
+++ b/src/cae_tools/cli/train_cae.py
@@ -40,10 +40,11 @@ def main():
     test_ds = [xr.open_dataset(test_input) for test_input in args.test_inputs]
     target_dimension = train_ds[0][args.output_variable].dims[0]
 
+
     train_ds = train_ds[0] if len(train_ds) == 1 else xr.concat(train_ds, dim=target_dimension)
     test_ds = test_ds[0] if len(test_ds) == 1 else xr.concat(test_ds, dim=target_dimension)
 
-    print(train_ds)
+    print("Training cases: %d, Test cases: %d"%(train_ds[target_dimension].shape[0],test_ds[target_dimension].shape[0]))
 
     training_paths = ";".join(args.train_inputs)
     test_paths = ";".join(args.test_inputs)
@@ -84,5 +85,8 @@ def main():
                 spec.load(json.loads(f.read()))
                 mt.spec = spec
 
-    mt.train(args.input_variables, args.output_variable, train_ds, test_ds, args.model_folder, training_paths, test_paths)
+    mt.train(args.input_variables, args.output_variable, training_ds=train_ds, testing_ds=test_ds, model_path=args.model_folder, training_paths=training_paths,
+             testing_paths=test_paths)
 
+if __name__ == '__main__':
+    main()

--- a/src/cae_tools/cli/train_cae.py
+++ b/src/cae_tools/cli/train_cae.py
@@ -2,6 +2,8 @@ import argparse
 import json
 import os
 
+import xarray as xr
+
 from cae_tools.models.conv_ae_model import ConvAEModel
 from cae_tools.models.var_ae_model import VarAEModel
 from cae_tools.models.linear_model import LinearModel
@@ -11,8 +13,8 @@ def main():
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("training_path",help="path to netcdf4 file containing training data")
-    parser.add_argument("test_path", help="path to netcdf4 file containing test data")
+    parser.add_argument("--train-inputs", nargs="+", help="path(s) to netcdf4 file containing training data", required=True)
+    parser.add_argument("--test-inputs", nargs="+", help="path(s) to netcdf4 file containing test data", required=True)
     parser.add_argument("--model-folder", help="folder to save the trained model to",required=True)
     parser.add_argument("--continue-training", action="store_true", help="continue training model")
     parser.add_argument("--input-variables", nargs="+", help="name of the input variable(s) in training/test data", required=True)
@@ -33,6 +35,18 @@ def main():
                         default=None)
 
     args = parser.parse_args()
+
+    train_ds = [xr.open_dataset(train_input) for train_input in args.train_inputs]
+    test_ds = [xr.open_dataset(test_input) for test_input in args.test_inputs]
+    target_dimension = train_ds[0][args.output_variable].dims[0]
+
+    train_ds = train_ds[0] if len(train_ds) == 1 else xr.concat(train_ds, dim=target_dimension)
+    test_ds = test_ds[0] if len(test_ds) == 1 else xr.concat(test_ds, dim=target_dimension)
+
+    print(train_ds)
+
+    training_paths = ";".join(args.train_inputs)
+    test_paths = ";".join(args.test_inputs)
 
     if args.continue_training:
         parameters_path = os.path.join(args.model_folder, "parameters.json")
@@ -70,5 +84,5 @@ def main():
                 spec.load(json.loads(f.read()))
                 mt.spec = spec
 
-    mt.train(args.input_variables, args.output_variable, args.training_path, args.test_path, args.model_folder)
+    mt.train(args.input_variables, args.output_variable, train_ds, test_ds, args.model_folder, training_paths, test_paths)
 

--- a/src/cae_tools/models/conv_ae_model.py
+++ b/src/cae_tools/models/conv_ae_model.py
@@ -236,20 +236,22 @@ class ConvAEModel(BaseModel):
                 save_arr[ctr:ctr + self.batch_size, :, :, :] = decoded_data.cpu()
                 ctr += self.batch_size
 
-    def train(self, input_variables, output_variable, training_path, test_path, model_path=""):
+    def train(self, input_variables, output_variable, training_ds, testing_ds, model_path="", training_paths="", test_paths=""):
         """
         Train the model (or continue training)
 
         :param input_variables: names of th input variables in training/test datasets
         :param output_variable: name of the output variable in training/test datasets
-        :param training_path: path to a netcdf4 file containing input and output 4D arrays orgainsed by (N,CHAN,Y,X)
-        :param test_path: path to a netcdf4 file to use for testing only.  Format as above
+        :param training_ds: an xarray dataset containing input and output 4D arrays orgainsed by (N,CHAN,Y,X)
+        :param testing_ds: an xarray dataset to use for testing only.  Format as above
         :param model_path: path to save model to after training
+        :param training_paths: a string providing a lst of all the training data paths
+        :param test_paths: a string providing a list of all the test data paths
         """
-        train_ds = DSDataset(xr.open_dataset(training_path), input_variables, output_variable,
+        train_ds = DSDataset(training_ds, input_variables, output_variable,
                              normalise_in=self.normalise_input, normalise_out=self.normalise_output)
         self.normalisation_parameters = train_ds.get_normalisation_parameters()
-        test_ds = DSDataset(xr.open_dataset(test_path), input_variables, output_variable,
+        test_ds = DSDataset(testing_ds, input_variables, output_variable,
                             normalise_in=self.normalise_input, normalise_out=self.normalise_output)
         test_ds.set_normalisation_parameters(self.normalisation_parameters)
         (input_chan, input_y, input_x) = train_ds.get_input_shape()
@@ -334,7 +336,7 @@ class ConvAEModel(BaseModel):
 
         if self.db:
             self.db.add_training_result(self.get_model_id(), "ConvAE", output_variable, input_variables, self.summary(),
-                                        model_path, training_path, train_loss, test_path, test_loss, self.get_parameters(), self.spec.save())
+                                        model_path, training_paths, train_loss, test_paths, test_loss, self.get_parameters(), self.spec.save())
         if model_path:
             self.save(model_path)
 
@@ -348,7 +350,7 @@ class ConvAEModel(BaseModel):
         self.dump_metrics("Train Metrics",metrics["train"])
 
         if self.db:
-            self.db.add_evaluation_result(self.get_model_id(),training_path, test_path, metrics)
+            self.db.add_evaluation_result(self.get_model_id(), training_paths, test_paths, metrics)
 
 
     def apply(self, input_path, input_variables, output_path, prediction_variable="model_output",

--- a/src/cae_tools/models/conv_ae_model.py
+++ b/src/cae_tools/models/conv_ae_model.py
@@ -28,7 +28,7 @@ from .ds_dataset import DSDataset
 from .encoder import Encoder
 from .decoder import Decoder
 from ..utils.model_database import ModelDatabase
-from .model_metric import ModelMetric
+
 
 class ConvAEModel(BaseModel):
 
@@ -236,7 +236,7 @@ class ConvAEModel(BaseModel):
                 save_arr[ctr:ctr + self.batch_size, :, :, :] = decoded_data.cpu()
                 ctr += self.batch_size
 
-    def train(self, input_variables, output_variable, training_ds, testing_ds, model_path="", training_paths="", test_paths=""):
+    def train(self, input_variables, output_variable, training_ds, testing_ds, model_path="", training_paths="", testing_paths=""):
         """
         Train the model (or continue training)
 
@@ -246,7 +246,7 @@ class ConvAEModel(BaseModel):
         :param testing_ds: an xarray dataset to use for testing only.  Format as above
         :param model_path: path to save model to after training
         :param training_paths: a string providing a lst of all the training data paths
-        :param test_paths: a string providing a list of all the test data paths
+        :param testing_paths: a string providing a list of all the test data paths
         """
         train_ds = DSDataset(training_ds, input_variables, output_variable,
                              normalise_in=self.normalise_input, normalise_out=self.normalise_output)
@@ -336,7 +336,7 @@ class ConvAEModel(BaseModel):
 
         if self.db:
             self.db.add_training_result(self.get_model_id(), "ConvAE", output_variable, input_variables, self.summary(),
-                                        model_path, training_paths, train_loss, test_paths, test_loss, self.get_parameters(), self.spec.save())
+                                        model_path, training_paths, train_loss, testing_paths, test_loss, self.get_parameters(), self.spec.save())
         if model_path:
             self.save(model_path)
 
@@ -350,55 +350,8 @@ class ConvAEModel(BaseModel):
         self.dump_metrics("Train Metrics",metrics["train"])
 
         if self.db:
-            self.db.add_evaluation_result(self.get_model_id(), training_paths, test_paths, metrics)
+            self.db.add_evaluation_result(self.get_model_id(), training_paths, testing_paths, metrics)
 
-
-    def apply(self, input_path, input_variables, output_path, prediction_variable="model_output",
-                channel_dimension="model_output_channel",y_dimension="model_output_y",x_dimension="model_output_x"):
-        """
-        Apply this model to input data to produce an output estimate
-
-        :param input_path: path to a netcdf4 file containing input data
-        :param input_variables: name of the input variables in the input data
-        :param output_path: path to a netcdf4 file to write containing the input data plus a prediction variable
-        :param prediction_variable: the name of the prediction variable
-        :param channel_dimension: the name of the channel dimension in the prediction variable
-        :param y_dimension: the name of the y dimension in the prediction variable
-        :param x_dimension: the name of the x dimension in the prediction variable
-        """
-        score_ds = xr.open_dataset(input_path)
-        # print("Input variables:", score_ds)
-        # print("First item in input_variables:", input_variables[0])
-
-        n = score_ds[input_variables[0]].shape[0]
-        n_dimension = score_ds[input_variables[0]].dims[0]
-        out_chan = self.output_shape[0]
-        out_y = self.output_shape[1]
-        out_x = self.output_shape[2]
-        score_arr = np.zeros(shape=(n,out_chan,out_y,out_x))
-
-        ds = DSDataset(score_ds, input_variables, input_variables[0], normalise_in=self.normalise_input)
-        ds.set_normalisation_parameters(self.normalisation_parameters)
-        val_loader = torch.utils.data.DataLoader(ds, batch_size=self.batch_size)
-
-        if self.use_gpu:
-            device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-        else:
-            device = torch.device("cpu")
-
-        self.encoder.to(device)
-        self.decoder.to(device)
-
-        score_batches = []
-        for low_res, _, _ in val_loader:
-            low_res = low_res.to(device)
-            score_batches.append(low_res)
-
-        self.score(score_batches, save_arr=score_arr)
-        score_ds[prediction_variable] = xr.DataArray(ds.denormalise_output(score_arr),
-                dims=(n_dimension, channel_dimension, y_dimension, x_dimension))
-
-        score_ds.to_netcdf(output_path)
 
     def summary(self):
         """

--- a/src/cae_tools/models/var_ae_model.py
+++ b/src/cae_tools/models/var_ae_model.py
@@ -366,21 +366,23 @@ class VarAEModel(BaseModel):
                 save_arr[ctr:ctr + self.batch_size, :, :, :] = decoded_data.cpu()
                 ctr += self.batch_size
 
-
-    def train(self, input_variables, output_variable, training_path, test_path, model_path=""):
+    def train(self, input_variables, output_variable, training_ds, testing_ds, model_path="", training_paths="",
+              test_paths=""):
         """
         Train the model (or continue training)
 
         :param input_variables: names of th input variables in training/test datasets
         :param output_variable: name of the output variable in training/test datasets
-        :param training_path: path to a netcdf4 file containing input and output 4D arrays orgainsed by (N,CHAN,Y,X)
-        :param test_path: path to a netcdf4 file to use for testing only.  Format as above
+        :param training_ds: an xarray dataset containing input and output 4D arrays orgainsed by (N,CHAN,Y,X)
+        :param testing_ds: an xarray dataset to use for testing only.  Format as above
         :param model_path: path to save model to after training
+        :param training_paths: a string providing a lst of all the training data paths
+        :param test_paths: a string providing a list of all the test data paths
         """
-        train_ds = DSDataset(xr.open_dataset(training_path), input_variables, output_variable,
+        train_ds = DSDataset(training_ds, input_variables, output_variable,
                              normalise_in=self.normalise_input, normalise_out=self.normalise_output)
         self.normalisation_parameters = train_ds.get_normalisation_parameters()
-        test_ds = DSDataset(xr.open_dataset(test_path), input_variables, output_variable,
+        test_ds = DSDataset(testing_ds, input_variables, output_variable,
                             normalise_in=self.normalise_input, normalise_out=self.normalise_output)
         test_ds.set_normalisation_parameters(self.normalisation_parameters)
         (input_chan, input_y, input_x) = train_ds.get_input_shape()
@@ -470,7 +472,7 @@ class VarAEModel(BaseModel):
 
         if self.db:
             self.db.add_training_result(self.get_model_id(), "VarAE", output_variable, input_variables, self.summary(),
-                                        model_path, training_path, train_loss, test_path, test_loss,
+                                        model_path, training_paths, train_loss, test_paths, test_loss,
                                         self.get_parameters(), self.spec.save())
         if model_path:
             self.save(model_path)
@@ -484,7 +486,7 @@ class VarAEModel(BaseModel):
         self.dump_metrics("Train Metrics", metrics["train"])
 
         if self.db:
-            self.db.add_evaluation_result(self.get_model_id(), training_path, test_path, metrics)
+            self.db.add_evaluation_result(self.get_model_id(), training_paths, test_paths, metrics)
 
     def apply(self, input_path, input_variables, output_path, prediction_variable="model_output",
                 channel_dimension="model_output_channel",y_dimension="model_output_y",x_dimension="model_output_x"):

--- a/test/cli/test_cli.sh
+++ b/test/cli/test_cli.sh
@@ -5,7 +5,7 @@
 
 here=`dirname $0`
 
-NR_EPOCHS=20
+NR_EPOCHS=200
 
 # for each supported method, go through the train, apply, evaluate, retrain, apply, evaluate cycle
 

--- a/test/cli/test_cli.sh
+++ b/test/cli/test_cli.sh
@@ -13,7 +13,7 @@ for method in linear conv var
 do
   echo tests for $method
   echo training model
-  train_cae --database-path $here/results.db $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
+  train_cae --database-path $here/results.db --train-inputs $here/../data/circle/16x16_256x256/train.nc --test-inputs $here/../data/circle/16x16_256x256/test.nc --method $method --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
 
   echo applying trained model to training and test datasets
   apply_cae $here/../data/circle/16x16_256x256/train.nc $here/results/$method/train_scores.nc --model-folder=$here/results/$method/mymodel --input-variables lowres --prediction-variable hires_estimate
@@ -23,7 +23,7 @@ do
   evaluate_cae $here/results/$method/train_scores.nc $here/results/$method/test_scores.nc $here/results/$method/model_evaluation.html --input-variables lowres --output-variable hires --model-folder=$here/results/$method/mymodel --prediction-variable hires_estimate
 
   echo retrain model
-  train_cae --database-path $here/results.db $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --continue-training --input-variables lowres --output-variable=hires --model-folder=$here/results/$method/mymodel --nr-epochs=$NR_EPOCHS
+  train_cae --database-path $here/results.db --train-inputs $here/../data/circle/16x16_256x256/train.nc --test-inputs $here/../data/circle/16x16_256x256/test.nc --continue-training --input-variables lowres --output-variable=hires --model-folder=$here/results/$method/mymodel --nr-epochs=$NR_EPOCHS
 
   echo applying retrained model to training and test datasets
   apply_cae $here/../data/circle/16x16_256x256/train.nc $here/results/$method/retrain_scores.nc --model-folder=$here/results/$method/mymodel --input-variables lowres --prediction-variable hires_estimate

--- a/test/cli/test_cli_train_cae.sh
+++ b/test/cli/test_cli_train_cae.sh
@@ -3,4 +3,4 @@ here=`dirname $0`
 NR_EPOCHS=10
 
 echo training model
-train_cae --database-path $here/results.db $here/../data/circle/16x16_256x256/train.nc $here/../data/circle/16x16_256x256/test.nc --method conv --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS
+train_cae --database-path $here/results.db --train-inputs $here/../data/circle/16x16_256x256/train.nc --test-inputs $here/../data/circle/16x16_256x256/test.nc --method conv --model-folder=$here/results/$method/mymodel --latent-size=8 --learning-rate 0.0005 --batch-size 20 --fc-size=32 --kernel-size=3 --stride=2 --input-variables lowres --output-variable=hires --nr-epochs=$NR_EPOCHS

--- a/test/unittests/quick_cae.py
+++ b/test/unittests/quick_cae.py
@@ -66,7 +66,7 @@ class QuickTest(unittest.TestCase):
         test_ds = xr.open_dataset(test_path)
 
         mt = ConvAEModel(**hyperparameters)
-        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, test_paths=test_path)
+        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, testing_paths=test_path)
         print(mt.summary())
 
         results_folder = os.path.join(results_root_folder, test_spec_name, f"{i_h}x{i_w}_{o_h}x{o_w}")
@@ -80,8 +80,14 @@ class QuickTest(unittest.TestCase):
         mt2 = ConvAEModel()
         mt2.load(model_path)
 
-        mt2.apply(train_path, input_variables, train_scores_path, estimated_output_variable)
-        mt2.apply(test_path, input_variables, test_scores_path, estimated_output_variable)
+        train_scores_ds = xr.open_dataset(train_path)
+        mt2.apply(train_scores_ds, input_variables, estimated_output_variable)
+        train_scores_ds.to_netcdf(train_scores_path)
+
+        test_scores_ds = xr.open_dataset(test_path)
+        mt2.apply(test_scores_ds, input_variables, estimated_output_variable)
+        test_scores_ds.to_netcdf(test_scores_path)
+
         evaluation_html_path = os.path.join(results_folder, "model_evaluation.html")
 
         me = ModelEvaluator(train_scores_path, test_scores_path, input_variables[0:1], output_variable, evaluation_html_path,

--- a/test/unittests/quick_cae.py
+++ b/test/unittests/quick_cae.py
@@ -15,6 +15,7 @@
 
 import unittest
 import os.path
+import xarray as xr
 
 from cae_tools.models.conv_ae_model import ConvAEModel
 from cae_tools.models.model_evaluator import ModelEvaluator
@@ -22,7 +23,6 @@ from cae_tools.models.model_evaluator import ModelEvaluator
 import test_specs
 
 data_root_folder = os.path.join(os.path.split(__file__)[0],"..","data")
-
 
 results_root_folder = os.path.join(os.path.split(__file__)[0],"..","results","cae_quick")
 
@@ -61,8 +61,12 @@ class QuickTest(unittest.TestCase):
 
         train_path = os.path.join(folder, "train.nc")
         test_path = os.path.join(folder, "test.nc")
+
+        train_ds = xr.open_dataset(train_path)
+        test_ds = xr.open_dataset(test_path)
+
         mt = ConvAEModel(**hyperparameters)
-        mt.train(input_variables, output_variable, train_path, test_path)
+        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, test_paths=test_path)
         print(mt.summary())
 
         results_folder = os.path.join(results_root_folder, test_spec_name, f"{i_h}x{i_w}_{o_h}x{o_w}")

--- a/test/unittests/quick_linear.py
+++ b/test/unittests/quick_linear.py
@@ -72,7 +72,7 @@ class LinearTest(unittest.TestCase):
         test_ds = xr.open_dataset(test_path)
 
         mt = LinearModel(**hyperparameters)
-        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, test_paths=test_path)
+        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, testing_paths=test_path)
         print(mt.summary())
 
         results_folder = os.path.join(results_root_folder, test_spec_name, f"{i_h}x{i_w}_{o_h}x{o_w}")
@@ -86,8 +86,14 @@ class LinearTest(unittest.TestCase):
         mt2 = LinearModel()
         mt2.load(model_path)
 
-        mt2.apply(train_path, input_variables, train_scores_path, estimated_output_variable)
-        mt2.apply(test_path, input_variables, test_scores_path, estimated_output_variable)
+        train_scores_ds = xr.open_dataset(train_path)
+        mt2.apply(train_scores_ds, input_variables, estimated_output_variable)
+        train_scores_ds.to_netcdf(train_scores_path)
+
+        test_scores_ds = xr.open_dataset(test_path)
+        mt2.apply(test_scores_ds, input_variables, estimated_output_variable)
+        test_scores_ds.to_netcdf(test_scores_path)
+
         evaluation_html_path = os.path.join(results_folder, "model_evaluation.html")
 
         me = ModelEvaluator(train_scores_path, test_scores_path, input_variables[0:1], output_variable, evaluation_html_path,

--- a/test/unittests/quick_linear.py
+++ b/test/unittests/quick_linear.py
@@ -15,6 +15,7 @@
 
 import unittest
 import os.path
+import xarray as xr
 
 from cae_tools.models.linear_model import LinearModel
 from cae_tools.models.model_evaluator import ModelEvaluator
@@ -66,8 +67,12 @@ class LinearTest(unittest.TestCase):
 
         train_path = os.path.join(folder, "train.nc")
         test_path = os.path.join(folder, "test.nc")
+
+        train_ds = xr.open_dataset(train_path)
+        test_ds = xr.open_dataset(test_path)
+
         mt = LinearModel(**hyperparameters)
-        mt.train(input_variables, output_variable, train_path, test_path)
+        mt.train(input_variables, output_variable, train_ds, test_ds, training_paths=train_path, test_paths=test_path)
         print(mt.summary())
 
         results_folder = os.path.join(results_root_folder, test_spec_name, f"{i_h}x{i_w}_{o_h}x{o_w}")


### PR DESCRIPTION
Breaking changes - specify `--train-inputs` and `--test-inputs` in `train_cae`, can provide multiple file paths as arguments, eg

```
train_cae --train-inputs input1.nc input2.nc --test-inputs input3.nc input4.nc ...
```

`apply_cae` now allows multiple input files which are concatenated and then scored 

```
apply_cae input1.nc input2.nc input3.nc scores.nc ...
```

Some refactoring, move identical apply method in Conv and Var models to base class